### PR TITLE
Bug: Call Tracing.Monitor.monitor instead of Tracing.monitor

### DIFF
--- a/lib/tracing.ex
+++ b/lib/tracing.ex
@@ -154,7 +154,7 @@ defmodule Tracing do
       parent_span = OpenTelemetry.Tracer.current_span_ctx()
 
       if unquote(opts)[:monitor] do
-        Tracing.monitor(parent_span)
+        Tracing.Monitor.monitor(parent_span)
       end
 
       fn unquote_splicing(fun_args) ->


### PR DESCRIPTION
The function is calling the wrong module. This used to be `OpenTelemetryMonitor.monitor` and the rename has gone wrong.